### PR TITLE
Lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,53 @@
+module.exports = {
+  parser: '@typescript-eslint/parser', // Specifies the ESLint parser
+  // plugins: [
+  //   '@typescript-eslint',
+  // ],
+  parserOptions: {
+    ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features
+    sourceType: 'module', // Allows for the use of imports
+    ecmaFeatures: {
+      jsx: true // Allows for the parsing of JSX
+    }
+  },
+  settings: {
+    react: {
+      version: 'detect' // Tells eslint-plugin-react to automatically detect the version of React to use
+    }
+  },
+  extends: [
+    'plugin:react/recommended', // Uses the recommended rules from @eslint-plugin-react
+    'plugin:@typescript-eslint/recommended', // Uses the recommended rules from @typescript-eslint/eslint-plugin
+    "prettier/@typescript-eslint", // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
+    "plugin:prettier/recommended", // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+    'react-app', // Uses recommended rules from react-scripts
+  ],
+  rules: {
+    // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
+    // eslint rules: https://eslint.org/docs/rules/
+    // @typescript-eslint rules: https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin
+    '@typescript-eslint/explicit-function-return-type': 'off', // with this we won't need to specify functions return types. Typescript will infer it for us
+    'no-console': 'warn', // Lets not leave console.logs all over
+    curly: 'warn', // forces { and } after ifs, while, for, etc
+    indent: ['warn', 2],
+    'sort-imports': 'error',
+    quotes: 'off', // forces single quotes
+    '@typescript-eslint/quotes': ['warn', 'single', {
+      avoidEscape: true,
+      allowTemplateLiterals: true,
+    }],
+    'eol-last': 'warn', // adds an empty line at the end of the file
+    '@typescript-eslint/member-ordering': 'warn', // forces a specific order for class members
+    '@typescript-eslint/member-delimiter-style': ['warn'], // forces us to use semicollon when separating members of types
+    'comma-spacing': 'off',
+    '@typescript-eslint/comma-spacing': 'warn', // forces no spaces before a comma and at least one after a comma
+    'comma-dangle': ['warn', 'always-multiline'], // forces us to leave a comma after the last item of an array and object literal, function, etc, when they span multiple lines
+    'comma-style': 'warn', // when we need to break lines around a comma, this will force us to leave a comma before the line break
+    'no-multiple-empty-lines': ['warn', {
+      max: 2,
+      maxEOF: 1,
+      maxBOF: 0,
+    }], // allows us to have at most 2 consecutives empty lines 
+    'no-trailing-spaces': 'warn', // no whitespaces after lines
+  },
+};

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  semi: true,
+  trailingComma: 'all',
+  singleQuote: true,
+  // printWidth: 120,
+  tabWidth: 2,
+  arrowParens: 'avoid',
+  jsxSingleQuote: true,
+  jsxBracketSameLine: false,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4828,6 +4828,14 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
+      "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
     "eslint-config-react-app": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-5.2.1.tgz",
@@ -5027,6 +5035,14 @@
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz",
+      "integrity": "sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==",
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-react": {
@@ -5439,6 +5455,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
       "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
     },
     "fast-glob": {
       "version": "2.2.7",
@@ -5869,6 +5890,11 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
     },
     "get-stream": {
       "version": "4.1.0",
@@ -10445,6 +10471,19 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg=="
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-bytes": {
       "version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "@types/node": "^12.12.37",
     "@types/react": "^16.9.34",
     "@types/react-dom": "^16.9.7",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-prettier": "^3.1.3",
+    "prettier": "^2.0.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
@@ -19,7 +22,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "lint": "eslint --max-warnings 0 **/*.ts[x]",
+    "lint:fix": "eslint --fix --max-warnings 0 **/*.ts[x]"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,6 @@
+import App from './App';
 import React from 'react';
 import { render } from '@testing-library/react';
-import App from './App';
 
 test('renders learn react link', () => {
   const { getByText } = render(<App />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,20 @@
+import './App.css';
 import React from 'react';
 import logo from './logo.svg';
-import './App.css';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
+    <div className='App'>
+      <header className='App-header'>
+        <img src={logo} className='App-logo' alt='logo' />
         <p>
           Edit <code>src/App.tsx</code> and save to reload.
         </p>
         <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
+          className='App-link'
+          href='https://reactjs.org'
+          target='_blank'
+          rel='noopener noreferrer'
         >
           Learn React
         </a>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,14 @@
+import './index.css';
+import * as serviceWorker from './serviceWorker';
+import App from './App';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import * as serviceWorker from './serviceWorker';
 
 ReactDOM.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById('root'),
 );
 
 // If you want your app to work offline and load faster, you can change


### PR DESCRIPTION
Configured eslint to be used with typescript. It will also load some configs from prettier. The options are commented in the config file itself.

I choose to not enforce the rules when running `npm start` cause it would display the errors in the browser and whould not render anything until fixed, and that would be very annoying.

I also fixed the errors that appeared in the files.